### PR TITLE
Allow to use PHP8 with symfony4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=7.4 || ^8.0",
         "ext-json": "*",
-        "symfony/framework-bundle": "^5.0"
+        "symfony/framework-bundle": "^4.3||^5.0"
     },
     "require-dev": {
         "doctrine/annotations": "^1.0",


### PR DESCRIPTION
Hi. Currently it's impossible to update Symfony4 project to use with PHP8.

I can't user json-request-bundle v3 because it isn't compatible with PHP8, and v4 is incompatible with Symfony4.
