### PR TITLE
Configurable json content types

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ public function indexAction(Request $request)
 }
 ```
 
+Per default request content will be transformed only for requests with content type `json` or `jsonld`.
+
+but you can stil configure it with
+
+``` yaml
+# serices.yaml
+
+json_request:
+    content_types:
+        - json
+        - jsonld
+        - someouthertype
+```
+
 [package-link]: https://packagist.org/packages/symfony-bundles/json-request-bundle
 [license-link]: https://github.com/symfony-bundles/json-request-bundle/blob/master/LICENSE
 [license-image]: https://poser.pugx.org/symfony-bundles/json-request-bundle/license

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace SymfonyBundles\JsonRequestBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder('json_request');
+
+        $treeBuilder->getRootNode()  // @phpstan-ignore-line
+            ->children()
+                ->arrayNode('content_types')
+                    ->beforeNormalization()
+                        ->ifNull()
+                        ->thenUnset()
+                    ->end()
+                    ->beforeNormalization()
+                        ->castToArray()
+                    ->end()
+                    ->defaultValue(['json', 'jsonld'])
+                    ->requiresAtLeastOneElement()
+                    ->scalarPrototype()->end()
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/src/DependencyInjection/JsonRequestExtension.php
+++ b/src/DependencyInjection/JsonRequestExtension.php
@@ -2,8 +2,8 @@
 
 namespace SymfonyBundles\JsonRequestBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use SymfonyBundles\JsonRequestBundle\EventListener\RequestTransformerListener;
@@ -12,9 +12,11 @@ final class JsonRequestExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container): void
     {
-        $listener = new Definition(RequestTransformerListener::class);
-        $listener->addTag('kernel.event_listener', ['event' => KernelEvents::REQUEST, 'priority' => 100]);
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new Configuration(), $configs);
 
-        $container->setDefinition(RequestTransformerListener::class, $listener);
+        $container->register(RequestTransformerListener::class)
+            ->addArgument($config['content_types'])
+            ->addTag('kernel.event_listener', ['event' => KernelEvents::REQUEST, 'priority' => 100]);
     }
 }

--- a/src/EventListener/RequestTransformerListener.php
+++ b/src/EventListener/RequestTransformerListener.php
@@ -9,6 +9,13 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 final class RequestTransformerListener
 {
+    private array $contentTypes;
+
+    public function __construct(array $contentTypes)
+    {
+        $this->contentTypes = $contentTypes;
+    }
+
     public function onKernelRequest(RequestEvent $event): void
     {
         $request = $event->getRequest();
@@ -30,6 +37,6 @@ final class RequestTransformerListener
 
     private function supports(Request $request): bool
     {
-        return 'json' === $request->getContentType() && $request->getContent();
+        return in_array($request->getContentType(), $this->contentTypes, true) && $request->getContent();
     }
 }

--- a/tests/Controller/ExampleControllerTest.php
+++ b/tests/Controller/ExampleControllerTest.php
@@ -17,6 +17,27 @@ final class ExampleControllerTest extends WebTestCase
         $this->assertSame($body, $response->getContent());
     }
 
+    public function testTransformJsonldRequest(): void
+    {
+        $body = \json_encode(['foo' => 'baz']);
+
+        $response = $this->sendRequest($body, 'application/ld+json');
+
+        $this->assertSame($body, $response->getContent());
+    }
+
+    public function testTransformSoneOtherTypeRequest(): void
+    {
+        $body = \json_encode(['foo' => 'baz']);
+
+        // add content type. they are stored in static Request::formats variable
+        (new Request())->setFormat('someother', 'application/some+other+type');
+
+        $response = $this->sendRequest($body, 'application/some+other+type');
+
+        $this->assertSame($body, $response->getContent());
+    }
+
     public function testInvalidBody(): void
     {
         $response = $this->sendRequest('{$body}');
@@ -24,7 +45,6 @@ final class ExampleControllerTest extends WebTestCase
         $this->assertSame('{"message":"Syntax error"}', $response->getContent());
         $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
     }
-
 
     public function testInvalidContentType(): void
     {

--- a/tests/DependencyInjectionTest.php
+++ b/tests/DependencyInjectionTest.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types=1);
+
+namespace SymfonyBundles\JsonRequestBundle\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use SymfonyBundles\JsonRequestBundle\DependencyInjection\JsonRequestExtension;
+use SymfonyBundles\JsonRequestBundle\EventListener\RequestTransformerListener;
+
+class DependencyInjectionTest extends TestCase
+{
+    protected ContainerBuilder $containerBuilder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->containerBuilder = new ContainerBuilder();
+    }
+
+    public function testContentTypesNotSet(): void
+    {
+        $extension = new JsonRequestExtension();
+        $config = [];
+
+        $extension->load([$config], $this->containerBuilder);
+
+        $this->assertContentTypes(['json', 'jsonld']);
+    }
+
+    public function testContentTypesIsNull(): void
+    {
+        $extension = new JsonRequestExtension();
+        $config = [
+            'content_types' => null,
+        ];
+
+        $extension->load([$config], $this->containerBuilder);
+
+        $this->assertContentTypes(['json', 'jsonld']);
+    }
+
+    public function testContentTypesAnotherArray(): void
+    {
+        $extension = new JsonRequestExtension();
+        $config = [
+            'content_types' => ['json', 'someother'],
+        ];
+
+        $extension->load([$config], $this->containerBuilder);
+
+        $this->assertContentTypes(['json', 'someother']);
+    }
+
+    public function testContentTypesAnotherInteger(): void
+    {
+        $extension = new JsonRequestExtension();
+        $config = [
+            'content_types' => [42],
+        ];
+
+        $extension->load([$config], $this->containerBuilder);
+
+        $this->assertContentTypes([42]);
+    }
+
+    public function testContentTypesShouldHaveAtLeastOneElement(): void
+    {
+        $this->expectExceptionMessage('should have at least 1 element(s) defined.');
+
+        $extension = new JsonRequestExtension();
+        $config = [
+            'content_types' => [],
+        ];
+
+        $extension->load([$config], $this->containerBuilder);
+    }
+
+    public function testContentTypesExpectedScalarStdClassGiven(): void
+    {
+        $this->expectExceptionMessage('Expected "scalar", but got "stdClass".');
+
+        $extension = new JsonRequestExtension();
+        $config = [
+            'content_types' => [new \stdClass()],
+        ];
+
+        $extension->load([$config], $this->containerBuilder);
+    }
+
+    public function testContentTypesExpectedScalarArrayGiven(): void
+    {
+        $this->expectExceptionMessage('Expected "scalar", but got "array"');
+
+        $extension = new JsonRequestExtension();
+        $config = [
+            'content_types' => ['json', ['array']],
+        ];
+
+        $extension->load([$config], $this->containerBuilder);
+    }
+
+    private function assertContentTypes(array $expected)
+    {
+        $listenerDefinition = $this->containerBuilder->findDefinition(RequestTransformerListener::class);
+        $this->assertEquals($expected, $listenerDefinition->getArgument(0));
+    }
+}

--- a/tests/Fixture/config/config.yaml
+++ b/tests/Fixture/config/config.yaml
@@ -6,3 +6,6 @@ services:
     SymfonyBundles\JsonRequestBundle\Tests\Fixture\App\Controller\:
         resource: '../App/Controller'
         tags: ['controller.service_arguments']
+
+json_request:
+    content_types: ['json', 'jsonld', 'someother']


### PR DESCRIPTION
According to #5 added `application/ld+json` to defaults and made expected json content types configurable with:

```yaml
# config/services.yaml

json_request:
    content_types: ['json', 'jsonld']
```