### PR TITLE
rename getContentType() method on Request class to getContentTypeFormat()

### DIFF
--- a/src/EventListener/RequestTransformerListener.php
+++ b/src/EventListener/RequestTransformerListener.php
@@ -37,6 +37,6 @@ final class RequestTransformerListener
 
     private function supports(Request $request): bool
     {
-        return in_array($request->getContentType(), $this->contentTypes, true) && $request->getContent();
+        return in_array(method_exists($request, 'getContentTypeFormat') ? $request->getContentTypeFormat() : $request->getContentType(), $this->contentTypes, true) && $request->getContent();
     }
 }

--- a/tests/EventListener/RequestTransformerListenerTest.php
+++ b/tests/EventListener/RequestTransformerListenerTest.php
@@ -23,6 +23,7 @@ class RequestTransformerListenerTest extends TestCase
     {
         $request = $this->createMock(Request::class);
         $request->method('getContent')->willReturn('{"test": "val}');
+        $request->method('getContentTypeFormat')->willReturn("json");
         $request->method('getContentType')->willReturn("json");
 
         $requestEvent = $this->createMock(RequestEvent::class);
@@ -44,6 +45,7 @@ class RequestTransformerListenerTest extends TestCase
         $request = $this->createMock(Request::class);
         $request->method('getContent')->willReturn('{"test": "val"}');
         $request->method('getContentType')->willReturn('json');
+        $request->method('getContentTypeFormat')->willReturn("json");
         $request->request = $inputBag;
 
         $requestEvent = $this->createMock(RequestEvent::class);


### PR DESCRIPTION
Fixes php-bundles/json-request-bundle#18